### PR TITLE
opacity and quad size optimizations

### DIFF
--- a/include/vkgs/scene/camera.h
+++ b/include/vkgs/scene/camera.h
@@ -14,6 +14,22 @@ class Camera {
   Camera();
   ~Camera();
 
+
+  //getters and setters for cam settings so we can copy and paste it
+  glm::vec3 GetCenter() const { return center_;}
+
+  void  SetCenter(const glm::vec3& c) { center_ = c;}
+  float GetRadius() const { return r_;}
+  float SetRadius(float r) { r_ = r; return r_;}
+  float GetPhi() const { return phi_;}
+  float SetPhi(float p) { phi_ = p; return phi_;}
+  float GetTheta() const {return theta_;}
+  float SetTheta(float t) {theta_ = t; return theta_;}
+  float GetFovy() const { return fovy_; }
+  float SetFovy(float f) { fovy_ = f; return fovy_;}
+
+
+
   auto Near() const noexcept { return near_; }
   auto Far() const noexcept { return far_; }
 

--- a/src/shader/splat.frag
+++ b/src/shader/splat.frag
@@ -1,12 +1,32 @@
 #version 460
+#extension GL_EXT_shader_atomic_float : enable
 
 layout(location = 0) in vec4 color;
 layout(location = 1) in vec2 position;
 
 layout(location = 0) out vec4 out_color;
 
+layout(set = 2, binding = 0, r32ui) uniform uimage2D counter_image;
+
 void main() {
+
+  ivec2 pixel = ivec2(gl_FragCoord.xy);
+
+  // Atomically increment the counter for this pixel
+  uint count = imageAtomicAdd(counter_image, pixel, 1);
+
+  // Set your limit here
+  uint max_splats = 4;
+  if (count >= max_splats)
+  {
+      discard;
+  }
+  float alpha_threshold = 0.1;
+  
   float gaussian_alpha = exp(-0.5f * dot(position, position));
   float alpha = color.a * gaussian_alpha;
+  if (alpha < alpha_threshold) {
+      discard;
+  }
   out_color = vec4(color.rgb, alpha);
 }

--- a/src/shader/splat.vert
+++ b/src/shader/splat.vert
@@ -19,8 +19,9 @@ void main() {
   vec2 position = vec2(vert_index / 2, vert_index % 2) * 2.f - 1.f;
 
   float confidence_radius = 3.f;
+  float scale = 1;
 
-  gl_Position = vec4(ndc_position + vec3(rot_scale * position * confidence_radius, 0.f), 1.f);
+  gl_Position = vec4(ndc_position + vec3(rot_scale * position * confidence_radius * scale, 0.f), 1.f);
   out_color = color;
-  out_position = position * confidence_radius;
+  out_position = position * confidence_radius * scale;
 }

--- a/src/vkgs/engine/engine.cc
+++ b/src/vkgs/engine/engine.cc
@@ -1017,6 +1017,56 @@ class Engine::Impl {
         }
         ImGui::PopID();
       }
+
+      //allows copying and pasting specific camera view to reproduce results better
+      
+      // Temporary buffer for copy/paste
+      static char camera_view_buf[128] = "";
+
+      
+      glm::vec3 center = camera_.GetCenter();
+      float r = camera_.GetRadius();
+      float phi = camera_.GetPhi();
+      float theta = camera_.GetTheta();
+      float fovy = camera_.GetFovy();
+
+      // Show and edit camera parameters
+      ImGui::InputFloat3("Center", glm::value_ptr(center));
+      ImGui::InputFloat("Radius", &r);
+      ImGui::InputFloat("Phi", &phi); 
+      ImGui::InputFloat("FovY", &fovy); 
+      // Apply changes if edited
+      if (ImGui::Button("Apply Camera Params")) {
+          camera_.SetCenter(center);
+          camera_.SetRadius(r);
+          camera_.SetPhi(phi);
+          camera_.SetTheta(theta);
+          camera_.SetFovy(fovy);
+      }
+
+      // Copy to clipboard
+      if (ImGui::Button("Copy View")) {
+          snprintf(camera_view_buf, sizeof(camera_view_buf), "%.6f %.6f %.6f %.6f %.6f %.6f %.6f",
+              center.x, center.y, center.z, r, phi, theta, fovy);
+          ImGui::SetClipboardText(camera_view_buf);
+      }
+      ImGui::SameLine();
+      if (ImGui::Button("Paste View")) {
+          const char* clip = ImGui::GetClipboardText();
+          if (clip && sscanf(clip, "%f %f %f %f %f %f %f",
+              &center.x, &center.y, &center.z, &r, &phi, &theta, &fovy) == 7) {
+              camera_.SetCenter(center);
+              camera_.SetRadius(r);
+              camera_.SetPhi(phi);
+              camera_.SetTheta(theta);
+              camera_.SetFovy(fovy);
+          }
+      }
+      ImGui::InputText("Camera View String", camera_view_buf, sizeof(camera_view_buf));
+
+
+
+
       ImGui::End();
       viewer_.EndUi();
     }


### PR DESCRIPTION
added a constant scale factor to rescale quads to better fit the splat. using 0.5 seems to considerably improve performance without affecting image quality that much.

added an opacity threshold to discard fragments with low opacity

implemented functionality to copy and paste camera view. helpful for benchmarking.